### PR TITLE
Hide the bid comment block when its falsy (i.e. "<empty>", null)

### DIFF
--- a/src/components/bid-item.tsx
+++ b/src/components/bid-item.tsx
@@ -110,16 +110,18 @@ export const BidItem = ({
               {formattedBidAmount}
             </Typography>
           </Stack>
-          <FilledTextarea
-            minRows={1}
-            value={bidComment}
-            readOnly
-            sx={{
-              color: "base.500",
-              "&:hover": { cursor: "default", bgcolor: "base.50" },
-              "& .MuiFilledInput-input:hover": { cursor: "default" },
-            }}
-          />
+          {bidComment ? (
+            <FilledTextarea
+              minRows={1}
+              value={bidComment}
+              readOnly
+              sx={{
+                color: "base.500",
+                "&:hover": { cursor: "default", bgcolor: "base.50" },
+                "& .MuiFilledInput-input:hover": { cursor: "default" },
+              }}
+            />
+          ) : null}
         </Stack>
         {isOwner && (
           <>

--- a/src/types/bid.ts
+++ b/src/types/bid.ts
@@ -20,7 +20,7 @@ export interface Bid {
   updateDate: string;
   latestDeliveryDate: string;
   bidStatus: BidStatus;
-  bidComment: string;
+  bidComment: string | null;
 }
 
 export type BidStatus = "NOT_CHOSEN" | "IS_CHOSEN";


### PR DESCRIPTION
Quick fix to resolve issue #37 

Additional changes:
* add `null` type to the `bidComment` property in `Bid` type since the data returned by the backend is acutally nullable